### PR TITLE
Build and publish packages automatically via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+python: 2.7
+
+env:
+  global:
+    # TODO: Build all *changed* packages.
+    - CONDA_PACKAGE=scrapy
+    - CONDA_USER=Scrapinghub
+    - CONDA_CHANNEL=dev
+    - CONDA_PLATFORM=linux-64
+    - CONDA_HOME=$HOME/miniconda
+    - CONDA_BUILDS=$CONDA_HOME/conda-bld
+    - BUILD_OUTPUT=$HOME/build
+    - PUBLISH_BRANCH=master
+    - secure: "XZNL110y8pN6qntp0ZwsseFKVpaianmAJkA40/4PURbfBeS/ecItyCzJYlcMMIahXek/w+jDaEnJN58xcOeD5XjCxAy3JqtmvAAwxpZw4LHJrtT1UEMvipA5F258gv8lGPpyXMYjLPFnCaMF8KDCKa9xhG7T/2Ye0ufzHYO16EfcEvKfr2tjq94Ks3NKYGFBLqF54QlKj0cbQ/c85gW1yxzyFwJuPj5P/lvnJSuI52NwhwxPvjX/9E0S30atTCeCnb3bxPQ0jaEhxphpdmAcNZBW5xCMByTdJ0v5li+EXWr3hQIRjeRj3EOBWySLKObb1/cF1C3494RQ8WGRH0Cfj5WAja/CYZtpp0wp0EwdNFiQl33PySVnTkjJk0DHbDgdUd1sq4e5/9wc0APOWaDT7QPvZo2JBKj+gcbh++I83ttKP1DoP8yCSOHnD9cWHkekx8PCeIHPl3x6LNQVMQ/ZW5u6QG4Fir7tO4fa/ke9nT9B6UvbJ8AL+vThNpsGGH+c3cLLpuVRxAzZmX5OHuvErzSYKFCd0CYSTMHdWp4A04w2/4ZdEppETcU2NUGYKrX7O27dspP8+lPgfh6zo/r/rQ8WNGTMR+E6qH8Ltr3XI7tpoarlti9PPliNBEB9M11UPoGeOsl7ET4QzQCySK8Y17RznB8omTUvHvdzqjz0wTo="
+
+install:
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $CONDA_HOME
+  - export PATH="$CONDA_HOME/bin:$PATH"
+  - conda config --set always_yes yes
+  - conda config --set show_channel_urls yes
+  - conda config --add channels $CONDA_USER
+  - conda clean --tarballs
+  - conda update -q conda
+  - conda install -q conda-build anaconda-client
+  - conda info -a
+
+script:
+  - conda build $CONDA_PACKAGE
+  - conda convert -q -p all $CONDA_BUILDS/$CONDA_PLATFORM/*.tar.bz2 -o $BUILD_OUTPUT
+
+after_success:
+  - test "$TRAVIS_BRANCH" = "$PUBLISH_BRANCH" && anaconda -t $ANACONDA_TOKEN upload -u $CONDA_USER -c $CONDA_CHANNEL --force $BUILD_OUTPUT/*/*.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,32 +3,51 @@ python: 2.7
 
 env:
   global:
-    # TODO: Build all *changed* packages.
-    - CONDA_PACKAGE=scrapy
-    - CONDA_USER=Scrapinghub
-    - CONDA_CHANNEL=dev
-    - CONDA_PLATFORM=linux-64
     - CONDA_HOME=$HOME/miniconda
-    - CONDA_BUILDS=$CONDA_HOME/conda-bld
-    - BUILD_OUTPUT=$HOME/build
+    - BUILD_OUTPUT=$HOME/builds
+    # By default use the repository owner as conda user.
+    - CONDA_USER=$(dirname $TRAVIS_REPO_SLUG)
+    # We upload to dev channel, these packages should be promoted to main
+    # channel manually.
+    - CONDA_CHANNEL=dev
+    # Travis provides free linux-64 containers, we use it as a base platform to
+    # convert the packages to other platforms.
+    - CONDA_PLATFORM=linux-64
     - PUBLISH_BRANCH=master
+    # Scrapinghub's ANACONDA_TOKEN encrypted value.
     - secure: "XZNL110y8pN6qntp0ZwsseFKVpaianmAJkA40/4PURbfBeS/ecItyCzJYlcMMIahXek/w+jDaEnJN58xcOeD5XjCxAy3JqtmvAAwxpZw4LHJrtT1UEMvipA5F258gv8lGPpyXMYjLPFnCaMF8KDCKa9xhG7T/2Ye0ufzHYO16EfcEvKfr2tjq94Ks3NKYGFBLqF54QlKj0cbQ/c85gW1yxzyFwJuPj5P/lvnJSuI52NwhwxPvjX/9E0S30atTCeCnb3bxPQ0jaEhxphpdmAcNZBW5xCMByTdJ0v5li+EXWr3hQIRjeRj3EOBWySLKObb1/cF1C3494RQ8WGRH0Cfj5WAja/CYZtpp0wp0EwdNFiQl33PySVnTkjJk0DHbDgdUd1sq4e5/9wc0APOWaDT7QPvZo2JBKj+gcbh++I83ttKP1DoP8yCSOHnD9cWHkekx8PCeIHPl3x6LNQVMQ/ZW5u6QG4Fir7tO4fa/ke9nT9B6UvbJ8AL+vThNpsGGH+c3cLLpuVRxAzZmX5OHuvErzSYKFCd0CYSTMHdWp4A04w2/4ZdEppETcU2NUGYKrX7O27dspP8+lPgfh6zo/r/rQ8WNGTMR+E6qH8Ltr3XI7tpoarlti9PPliNBEB9M11UPoGeOsl7ET4QzQCySK8Y17RznB8omTUvHvdzqjz0wTo="
 
 install:
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $CONDA_HOME
-  - export PATH="$CONDA_HOME/bin:$PATH"
+  - scripts/setup-conda.sh $CONDA_HOME
+
+before_script:
+  - source $CONDA_HOME/bin/activate root
   - conda config --set always_yes yes
   - conda config --set show_channel_urls yes
   - conda config --add channels $CONDA_USER
-  - conda clean --tarballs
-  - conda update -q conda
-  - conda install -q conda-build anaconda-client
   - conda info -a
 
 script:
-  - conda build $CONDA_PACKAGE
-  - conda convert -q -p all $CONDA_BUILDS/$CONDA_PLATFORM/*.tar.bz2 -o $BUILD_OUTPUT
+  # We can't use TRAVIS_COMMIT_RANGE as it may contain invalid references.
+  # See https://github.com/travis-ci/travis-ci/issues/2666
+  - TARGET_PACKAGES=$(scripts/modified-packages.sh $TRAVIS_COMMIT_RANGE || scripts/modified-packages.sh ${TRAVIS_COMMIT}^1...${TRAVIS_COMMIT})
+  - |
+    if [ -z "$TARGET_PACKAGES" ]; then
+      echo "Nothing to build"
+      exit 0
+    else
+      echo "Building: $TARGET_PACKAGES"
+      scripts/build-packages.sh $BUILD_OUTPUT $TARGET_PACKAGES || exit $?
+    fi
 
 after_success:
-  - test "$TRAVIS_BRANCH" = "$PUBLISH_BRANCH" && anaconda -t $ANACONDA_TOKEN upload -u $CONDA_USER -c $CONDA_CHANNEL --force $BUILD_OUTPUT/*/*.tar.bz2
+  # At the moment, I couldn't make it work the deploy with the "script"
+  # provider. So we deploy here when PUBLISH_BRANCH branch is being built.
+  # Note that TRAVIS_BRANCH is "master" on pull requests..
+  - |
+    if [ $TRAVIS_BRANCH == $PUBLISH_BRANCH -a $TRAVIS_PULL_REQUEST == "false" ]; then
+      echo "Uploading packages to $CONDA_USER/$CONDA_CHANNEL"
+      for TARBALL in $BUILD_OUTPUT/{linux,win,osx}-*/*.tar.bz2; do
+        anaconda -t $ANACONDA_TOKEN upload -u $CONDA_USER -c $CONDA_CHANNEL --force $TARBALL || exit 1
+      done
+    fi

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+OUTPUT_DIR=$1
+shift
+PACKAGES=$@
+
+if [ -z "$OUTPUT_DIR" -o -z "$PACKAGES" ]; then
+  echo "Usage: $0 <OUTPUT_DIR> <PACKAGE> ..."
+  exit 1
+fi
+
+if [ ! -d "$OUTPUT_DIR" ]; then
+  mkdir -p $OUTPUT_DIR
+fi
+
+set -ex
+
+conda -V
+
+for NAME in $PACKAGES; do
+  BUILD_OUTPUT=$(conda build --output $NAME)
+  conda build $NAME
+  conda convert -q -p all -o $OUTPUT_DIR $BUILD_OUTPUT
+done

--- a/scripts/modified-packages.sh
+++ b/scripts/modified-packages.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+COMMIT_RANGE=$1
+CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE)
+
+for FILE in $CHANGED_FILES; do
+  PACKAGE=$(dirname $FILE)
+  if [ -f "$PACKAGE/meta.yaml" ]; then
+    echo $PACKAGE
+  fi
+done | sort | uniq

--- a/scripts/setup-conda.sh
+++ b/scripts/setup-conda.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+CONDA_HOME=$1
+if [ -z "$CONDA_HOME" ]; then
+  echo "Usage: $0 <CONDA_HOME>"
+  exit 1
+fi
+
+set -ex
+
+OS_NAME=$(uname -s)
+OS_ARCH=$(uname -m)
+if [ $OS_NAME == "Linux" ]; then
+  CONDA_OS=Linux
+elif [ $OS_NAME == "Darwin" ]; then
+  CONDA_OS=MacOSX
+else
+  echo "Unsupported system: $OS_NAME"
+  exit 1
+fi
+
+CONDA_CMD=$CONDA_HOME/bin/conda
+if [ ! -f "$CONDA_CMD" ]; then
+  wget https://repo.continuum.io/miniconda/Miniconda-latest-${CONDA_OS}-${OS_ARCH}.sh -O ~/miniconda.sh
+  bash ~/miniconda.sh -b -f -p $CONDA_HOME
+  rm -f ~/miniconda.sh
+fi
+
+$CONDA_CMD update -qy conda
+$CONDA_CMD install -qy conda-build anaconda-client


### PR DESCRIPTION
This PR adds a travis configuration to build and publish packages automatically to Scrapinghub's anaconda.org channel. It includes Scrapy 1.0.3 and related dependencies not available in conda by default.
