### PR TITLE
[WIP] Added binstar.yml for Scrapy.

### DIFF
--- a/scrapy/.binstar.yml
+++ b/scrapy/.binstar.yml
@@ -1,0 +1,28 @@
+package: scrapy
+user: scrapinghub
+
+platform:
+  - linux-64
+  # XXX: We don't have build workers for the platforms below, yet.
+  # - linux-32
+  # - osx-64
+  # - win-32
+  # - win-64
+
+engine:
+  - python=2
+
+install:
+  - conda config --add channels scrapinghub
+  - conda config --set always_yes true
+
+script:
+  - conda build .
+
+build_targets:
+  - conda
+
+notifications:
+  email:
+    recipients: ['opensource@scrapinghub.com']
+


### PR DESCRIPTION
This build config only enables the platform linux-64 which is available
in the Anaconda's public build workers.
