### PR TITLE
Updated scrapy recipe to 1.0.5 version.

### DIFF
--- a/scrapy/meta.yaml
+++ b/scrapy/meta.yaml
@@ -1,17 +1,17 @@
 package:
   name: scrapy
-  version: "1.0.3"
+  version: "1.0.5"
 
 source:
-  fn: Scrapy-1.0.3.tar.gz
-  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.0.3.tar.gz
-  md5: cefb981076a26112d6f9b76cb7e5ba7d
+  fn: Scrapy-1.0.5.tar.gz
+  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.0.5.tar.gz
+  md5: b8483fbed91730d30fdf747b2cca8780
 
 build:
   entry_points:
     - scrapy = scrapy.cmdline:execute
 
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Build number is changed to 0 because this will be the first build for
this version.
