### PR TITLE
Scrapy 1.1.0

### DIFF
--- a/scrapy/meta.yaml
+++ b/scrapy/meta.yaml
@@ -1,18 +1,15 @@
 package:
   name: scrapy
-  version: "1.0.6"
+  version: "1.1.0rc1"
 
 source:
-  fn: Scrapy-1.0.6.tar.gz
-  url: https://pypi.python.org/packages/9d/bb/f88948090988641b4b4be26d8865f9668b7d0223b7b27e0ada351d41faaa/Scrapy-1.0.6.tar.gz
-  md5: 92c6d393e5fbf14a90543400e2c620d7
+  fn: Scrapy-1.1.0rc1.tar.gz
+  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.1.0rc1.tar.gz
+  md5: 79dad4579baf08589d3c69bba611328b
 
 build:
   entry_points:
     - scrapy = scrapy.cmdline:execute
-
-  skip: True  # [py3k]
-
   number: 0
 
 requirements:
@@ -25,6 +22,8 @@ requirements:
     - pyopenssl
     - cssselect >=0.9
     - six >=1.5.2
+    - parsel >=0.9.3
+    - pydispatcher >=2.0.5
     - service_identity
     - pywin32  # [win]
 
@@ -37,6 +36,8 @@ requirements:
     - pyopenssl
     - cssselect >=0.9
     - six >=1.5.2
+    - parsel >=0.9.3
+    - pydispatcher >=2.0.5
     - service_identity
     - pywin32  # [win]
 

--- a/scrapy/meta.yaml
+++ b/scrapy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: scrapy
-  version: "1.1.0rc1"
+  version: "1.1.0rc3"
 
 source:
-  fn: Scrapy-1.1.0rc1.tar.gz
-  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.1.0rc1.tar.gz
-  md5: 79dad4579baf08589d3c69bba611328b
+  fn: Scrapy-1.1.0rc3.tar.gz
+  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.1.0rc3.tar.gz
+  md5: 8fcd0ba400c685f14e530fc9c20894c1
 
 build:
   entry_points:

--- a/scrapy/meta.yaml
+++ b/scrapy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: scrapy
-  version: "1.1.0rc3"
+  version: "1.1.0rc4"
 
 source:
-  fn: Scrapy-1.1.0rc3.tar.gz
-  url: https://pypi.python.org/packages/source/S/Scrapy/Scrapy-1.1.0rc3.tar.gz
-  md5: 8fcd0ba400c685f14e530fc9c20894c1
+  fn: Scrapy-1.1.0rc4.tar.gz
+  url: https://github.com/scrapy/scrapy/archive/1.1.0rc4.tar.gz
+  md5: 5edecbf8b9185dcdaeb4a270acb625b3
 
 build:
   entry_points:
@@ -16,7 +16,7 @@ requirements:
   build:
     - python x.x
     - twisted >=10.0.0
-    - w3lib >=1.8.0
+    - w3lib >=1.13.0
     - queuelib
     - lxml
     - pyopenssl
@@ -30,7 +30,7 @@ requirements:
   run:
     - python x.x
     - twisted >=10.0.0
-    - w3lib >=1.8.0
+    - w3lib >=1.13.0
     - queuelib
     - lxml
     - pyopenssl

--- a/scrapy/meta.yaml
+++ b/scrapy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: scrapy
-  version: "1.1.0rc4"
+  version: "1.1.0"
 
 source:
-  fn: Scrapy-1.1.0rc4.tar.gz
-  url: https://github.com/scrapy/scrapy/archive/1.1.0rc4.tar.gz
-  md5: 5edecbf8b9185dcdaeb4a270acb625b3
+  fn: Scrapy-1.1.0.tar.gz
+  url: https://github.com/scrapy/scrapy/archive/1.1.0.tar.gz
+  md5: d14ced4ac88934603c92e3954968083f
 
 build:
   entry_points:
@@ -16,7 +16,7 @@ requirements:
   build:
     - python x.x
     - twisted >=10.0.0
-    - w3lib >=1.13.0
+    - w3lib >=1.14.2
     - queuelib
     - lxml
     - pyopenssl
@@ -30,7 +30,7 @@ requirements:
   run:
     - python x.x
     - twisted >=10.0.0
-    - w3lib >=1.13.0
+    - w3lib >=1.14.2
     - queuelib
     - lxml
     - pyopenssl


### PR DESCRIPTION
This branch contains the updates required for the upcoming Scrapy version with Python 3.x support.

**Note:** Even though we build packages for `win-*`, it cannot run because `twisted`'s windows support is not ready yet. See https://twistedmatrix.com/trac/ticket/8018 
